### PR TITLE
Fix a bug which deleted shields

### DIFF
--- a/Gadgetlemage/MainWindow.xaml.cs
+++ b/Gadgetlemage/MainWindow.xaml.cs
@@ -93,22 +93,31 @@ namespace Gadgetlemage
 
                 Dispatcher.Invoke(new Action(() =>
                 {
-                    btnCreate.IsEnabled = Model.Hooked && Model.Loaded;
-
-                    // Automatically creates the weapon if needed
-                    bool autoCreate = cbxAutoCreate.IsChecked ?? false;
-                    if (Model.Hooked && Model.Loaded && autoCreate)
+                    if (Model.Hooked && Model.Loaded)
                     {
-                        Model.AutomaticallyCreateWeapon();
+                        btnCreate.IsEnabled = true;
+                        // Automatically creates the weapon if needed
+                        if (cbxAutoCreate.IsChecked ?? false)
+                        {
+                            Model.AutomaticallyCreateWeapon();
+                        }
+                        
+                        // Automatically delete the shield if needed
+                        if (cbxAutoDelete.IsChecked ?? false)
+                        {
+                            Model.AutomaticallyRemoveShield();
+                        }
+                        
+                        // Stop searching once the associated Black Knight dies
+                        if (Model.SelectedWeapon.IsConditionSatisfied())
+                        {
+                            ct.IsCancellationRequested = true;
+                        }
                     }
-
-                    // Automatically delete the shield if needed
-                    bool autoDelete = cbxAutoDelete.IsChecked ?? false;
-                    if (Model.Hooked && Model.Loaded && autoDelete)
+                    else
                     {
-                        Model.AutomaticallyRemoveShield();
+                        btnCreate.IsEnabled = false;
                     }
-
                 }));
 
                 Thread.Sleep(Model.RefreshInterval);


### PR DESCRIPTION
If you get a shield from a black knight *other* than the one selected, it was being deleted regardless.
This fixes the problem by stopping the search once the black knight dies.

(Note that I haven't tested this change, I'm not anywhere near competent enough at this game)